### PR TITLE
Add ApolloStore.ALL_KEYS to notify all watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next version (unreleased)
 
-PUT_CHANGELOG_HERE
+- Add `ApolloStore.ALL_KEYS` to notify all watchers (#87)
 
 # Version 0.0.5
 _2024-12-18_

--- a/normalized-cache-incubating/api/normalized-cache-incubating.api
+++ b/normalized-cache-incubating/api/normalized-cache-incubating.api
@@ -1,4 +1,5 @@
 public abstract interface class com/apollographql/cache/normalized/ApolloStore {
+	public static final field Companion Lcom/apollographql/cache/normalized/ApolloStore$Companion;
 	public abstract fun accessCache (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun clearAll ()Z
 	public abstract fun dispose ()V
@@ -15,6 +16,10 @@ public abstract interface class com/apollographql/cache/normalized/ApolloStore {
 	public abstract fun writeOperation (Lcom/apollographql/apollo/api/Operation;Lcom/apollographql/apollo/api/Operation$Data;Lcom/apollographql/apollo/api/CustomScalarAdapters;Lcom/apollographql/cache/normalized/api/CacheHeaders;)Ljava/util/Set;
 	public abstract fun writeOptimisticUpdates (Lcom/apollographql/apollo/api/Fragment;Lcom/apollographql/cache/normalized/api/CacheKey;Lcom/apollographql/apollo/api/Fragment$Data;Ljava/util/UUID;Lcom/apollographql/apollo/api/CustomScalarAdapters;)Ljava/util/Set;
 	public abstract fun writeOptimisticUpdates (Lcom/apollographql/apollo/api/Operation;Lcom/apollographql/apollo/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo/api/CustomScalarAdapters;)Ljava/util/Set;
+}
+
+public final class com/apollographql/cache/normalized/ApolloStore$Companion {
+	public final fun getALL_KEYS ()Lkotlin/collections/AbstractSet;
 }
 
 public final class com/apollographql/cache/normalized/ApolloStore$DefaultImpls {

--- a/normalized-cache-incubating/api/normalized-cache-incubating.klib.api
+++ b/normalized-cache-incubating/api/normalized-cache-incubating.klib.api
@@ -85,6 +85,10 @@ abstract interface com.apollographql.cache.normalized/ApolloStore { // com.apoll
         final val data // com.apollographql.cache.normalized/ApolloStore.ReadResult.data|{}data[0]
             final fun <get-data>(): #A1 // com.apollographql.cache.normalized/ApolloStore.ReadResult.data.<get-data>|<get-data>(){}[0]
     }
+    final object Companion { // com.apollographql.cache.normalized/ApolloStore.Companion|null[0]
+        final val ALL_KEYS // com.apollographql.cache.normalized/ApolloStore.Companion.ALL_KEYS|{}ALL_KEYS[0]
+            final fun <get-ALL_KEYS>(): kotlin.collections/AbstractSet<kotlin/String> // com.apollographql.cache.normalized/ApolloStore.Companion.ALL_KEYS.<get-ALL_KEYS>|<get-ALL_KEYS>(){}[0]
+    }
 }
 final class com.apollographql.cache.normalized.api/CacheControlCacheResolver : com.apollographql.cache.normalized.api/CacheResolver { // com.apollographql.cache.normalized.api/CacheControlCacheResolver|null[0]
     constructor <init>(com.apollographql.cache.normalized.api/CacheResolver = ...) // com.apollographql.cache.normalized.api/CacheControlCacheResolver.<init>|<init>(com.apollographql.cache.normalized.api.CacheResolver){}[0]

--- a/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/ApolloStore.kt
+++ b/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/ApolloStore.kt
@@ -37,8 +37,21 @@ import kotlin.reflect.KClass
 interface ApolloStore {
   /**
    * Exposes the keys of records that have changed.
+   * A special key [ALL_KEYS] is used to indicate that all records have changed.
    */
   val changedKeys: SharedFlow<Set<String>>
+
+  companion object {
+    val ALL_KEYS = object : AbstractSet<String>() {
+      override val size = 0
+
+      override fun iterator() = emptySet<String>().iterator()
+
+      override fun equals(other: Any?) = other === this
+
+      override fun hashCode() = 0
+    }
+  }
 
   /**
    * Reads an operation from the store.
@@ -213,6 +226,8 @@ interface ApolloStore {
 
   /**
    * Publishes a set of keys that have changed. This will notify subscribers of [changedKeys].
+   *
+   * Pass [ALL_KEYS] to indicate that all records have changed, for instance after a [clearAll] operation.
    *
    * @see changedKeys
    *

--- a/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultApolloStore.kt
+++ b/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/DefaultApolloStore.kt
@@ -64,7 +64,7 @@ internal class DefaultApolloStore(
   }
 
   override suspend fun publish(keys: Set<String>) {
-    if (keys.isEmpty()) {
+    if (keys.isEmpty() && keys !== ApolloStore.ALL_KEYS) {
       return
     }
 

--- a/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
+++ b/normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/internal/WatcherInterceptor.kt
@@ -43,10 +43,10 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor, A
           emit(Unit)
         }
         .filter { changedKeys ->
-          if (changedKeys !is Set<*>) {
-            return@filter true
-          }
-          watchedKeys == null || changedKeys.intersect(watchedKeys!!).isNotEmpty()
+          changedKeys !is Set<*> ||
+              changedKeys === ApolloStore.ALL_KEYS ||
+              watchedKeys == null ||
+              changedKeys.intersect(watchedKeys!!).isNotEmpty()
         }.map {
           if (it == Unit) {
             flowOf(ApolloResponse.Builder(request.operation, request.requestUuid).exception(WatcherSentinel).build())

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -1,5 +1,6 @@
 package test
 
+import app.cash.turbine.test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.CustomScalarAdapters
@@ -44,6 +45,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 class WatcherTest {
@@ -642,6 +644,27 @@ class WatcherTest {
     job.cancel()
   }
 
+  @Test
+  fun publishAllKeys() = runTest(before = { setUp() }) {
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+    apolloClient.query(query)
+        .fetchPolicy(FetchPolicy.CacheOnly)
+        .watch()
+        .test(timeout = 3.hours) {
+          // Start empty
+          assertIs<CacheMissException>(awaitItem().exception)
+
+          // Add data to the cache
+          apolloClient.enqueueTestResponse(query, episodeHeroNameData)
+          apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+          assertEquals("R2-D2", awaitItem().data?.hero?.name)
+
+          // Clear the cache
+          store.clearAll()
+          store.publish(ApolloStore.ALL_KEYS)
+          assertIs<CacheMissException>(awaitItem().exception)
+        }
+  }
 }
 
 internal suspend fun <D> Channel<D>.assertCount(count: Int) {

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -45,7 +45,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 class WatcherTest {
@@ -650,7 +649,7 @@ class WatcherTest {
     apolloClient.query(query)
         .fetchPolicy(FetchPolicy.CacheOnly)
         .watch()
-        .test(timeout = 3.hours) {
+        .test {
           // Start empty
           assertIs<CacheMissException>(awaitItem().exception)
 


### PR DESCRIPTION
This can be used to notify all watchers after calling `clearAll`. Related to https://github.com/apollographql/apollo-kotlin/issues/2532