### PR TITLE
Use more parameters when possible

### DIFF
--- a/normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.android.kt
+++ b/normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.android.kt
@@ -1,12 +1,12 @@
 package com.apollographql.cache.normalized.sql.internal
 
+import android.os.Build
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import app.cash.sqldelight.db.QueryResult
 import com.apollographql.cache.normalized.sql.ApolloInitializer
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
-
 
 internal actual fun createDriver(name: String?, baseDir: String?, schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver {
   check(baseDir == null) {
@@ -22,4 +22,12 @@ internal actual fun createDriver(name: String?, baseDir: String?, schema: SqlSch
 
 internal actual fun maybeCreateOrMigrateSchema(driver: SqlDriver, schema: SqlSchema<QueryResult.Value<Unit>>) {
   // no-op
+}
+
+// See https://www.sqlite.org/limits.html#:~:text=Maximum%20Number%20Of%20Host%20Parameters
+// and https://developer.android.com/reference/android/database/sqlite/package-summary.html
+internal actual val parametersMax: Int = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+  999
+} else {
+  32767
 }

--- a/normalized-cache-sqlite-incubating/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.apple.kt
+++ b/normalized-cache-sqlite-incubating/src/appleMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.apple.kt
@@ -29,3 +29,5 @@ internal actual fun createDriver(name: String?, baseDir: String?, schema: SqlSch
 internal actual fun maybeCreateOrMigrateSchema(driver: SqlDriver, schema: SqlSchema<QueryResult.Value<Unit>>) {
   // no op
 }
+
+internal actual val parametersMax: Int = 999

--- a/normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/SqlNormalizedCache.kt
@@ -10,6 +10,7 @@ import com.apollographql.cache.normalized.api.RecordMerger
 import com.apollographql.cache.normalized.api.RecordMergerContext
 import com.apollographql.cache.normalized.api.withDates
 import com.apollographql.cache.normalized.sql.internal.RecordDatabase
+import com.apollographql.cache.normalized.sql.internal.parametersMax
 import kotlin.reflect.KClass
 
 class SqlNormalizedCache internal constructor(
@@ -88,7 +89,7 @@ class SqlNormalizedCache internal constructor(
     } else {
       emptySet()
     }
-    return (keys + referencedKeys).chunked(999).sumOf { chunkedKeys ->
+    return (keys + referencedKeys).chunked(parametersMax).sumOf { chunkedKeys ->
       recordDatabase.deleteRecords(chunkedKeys)
       recordDatabase.changes().toInt()
     }
@@ -126,7 +127,7 @@ class SqlNormalizedCache internal constructor(
   private fun selectRecords(keys: Collection<CacheKey>): List<Record> {
     return keys
         .map { it.key }
-        .chunked(999).flatMap { chunkedKeys ->
+        .chunked(parametersMax).flatMap { chunkedKeys ->
           recordDatabase.selectRecords(chunkedKeys)
         }
   }

--- a/normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.kt
+++ b/normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.kt
@@ -14,3 +14,6 @@ internal expect fun createDriver(name: String?, baseDir: String?, schema: SqlSch
  * Others like JVM don't do this automatically. This is when [maybeCreateOrMigrateSchema] is needed
  */
 internal expect fun maybeCreateOrMigrateSchema(driver: SqlDriver, schema: SqlSchema<QueryResult.Value<Unit>>)
+
+// See https://www.sqlite.org/limits.html#:~:text=Maximum%20Number%20Of%20Host%20Parameters
+internal expect val parametersMax: Int

--- a/normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.jvm.kt
+++ b/normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/cache/normalized/sql/internal/factoryImplementations.jvm.kt
@@ -52,3 +52,5 @@ internal actual fun maybeCreateOrMigrateSchema(driver: SqlDriver, schema: SqlSch
     driver.execute(null, "PRAGMA $versionPragma=$newVersion", 0)
   }
 }
+
+internal actual val parametersMax: Int = 999


### PR DESCRIPTION
Allows to execute fewer queries in modern devices