### PR TITLE
Don't depend on apollo-testing-support-internal

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ atomicfu = "0.23.1" # Must be the same version as the one used by apollo-testing
 sqldelight = "2.0.1"
 androidx-sqlite = "2.3.1"
 librarian = "0.0.8-SNAPSHOT-cd822254de75426f8f047a50bae467da872cc912"
+kotlinx-coroutines = "1.9.0"
 
 [libraries]
 apollo-api = { group = "com.apollographql.apollo", name = "apollo-api", version.ref = "apollo" }
@@ -24,6 +25,7 @@ atomicfu-plugin = { group = "org.jetbrains.kotlinx", name = "atomicfu-gradle-plu
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" } # the Kotlin plugin resolves the version
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit" } # the Kotlin plugin resolves the version
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
+okio-nodefilesystem = { group = "com.squareup.okio", name = "okio-nodefilesystem", version.ref = "okio" }
 uuid = "com.benasher44:uuid:0.8.2"
 sqldelight-android = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqldelight" }
 sqldelight-jvm = { group = "app.cash.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
@@ -37,6 +39,7 @@ androidx-sqlite-framework = { group = "androidx.sqlite", name = "sqlite-framewor
 androidx-startup-runtime = "androidx.startup:startup-runtime:1.1.1"
 kotlin-poet = { group = "com.squareup", name = "kotlinpoet", version = "1.18.1" }
 kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-plugin" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 librarian = { module = "com.gradleup.librarian:librarian-gradle-plugin", version.ref = "librarian"}
 android-plugin =  { module = "com.android.tools.build:gradle", version.ref = "android-plugin"}
 sqldelight-plugin = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight"}

--- a/normalized-cache-incubating/build.gradle.kts
+++ b/normalized-cache-incubating/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
+        implementation(project(":test-utils"))
       }
     }
   }

--- a/normalized-cache-incubating/src/commonTest/kotlin/com/apollographql/cache/normalized/internal/LruCacheTest.kt
+++ b/normalized-cache-incubating/src/commonTest/kotlin/com/apollographql/cache/normalized/internal/LruCacheTest.kt
@@ -1,7 +1,7 @@
 package com.apollographql.cache.normalized.internal
 
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.memory.internal.LruCache
+import com.apollographql.cache.normalized.testing.runTest
 import kotlinx.coroutines.delay
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/normalized-cache-sqlite-incubating/build.gradle.kts
+++ b/normalized-cache-sqlite-incubating/build.gradle.kts
@@ -86,7 +86,6 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
         implementation(project(":test-utils"))
       }
     }

--- a/test-utils/api/test-utils.api
+++ b/test-utils/api/test-utils.api
@@ -1,11 +1,56 @@
+public final class com/apollographql/cache/normalized/testing/-FileSystemCommon {
+	public static final fun pathToJsonReader (Ljava/lang/String;)Lcom/apollographql/apollo/api/json/JsonReader;
+	public static final fun pathToUtf8 (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class com/apollographql/cache/normalized/testing/CacheKeyKt {
 	public static final fun append-eNSUWrY (Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/String;
 	public static final fun fieldKey-eNSUWrY (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun keyToString-pWl1Des (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class com/apollographql/cache/normalized/testing/ChannelsKt {
+	public static final fun assertNoElement (Lkotlinx/coroutines/channels/Channel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun assertNoElement$default (Lkotlinx/coroutines/channels/Channel;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun awaitElement (Lkotlinx/coroutines/channels/Channel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitElement$default (Lkotlinx/coroutines/channels/Channel;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/apollographql/cache/normalized/testing/CurrentThreadId_jvmCommonKt {
+	public static final fun currentThreadId ()Ljava/lang/String;
+}
+
 public final class com/apollographql/cache/normalized/testing/ErrorsKt {
 	public static final fun assertErrorsEquals (Lcom/apollographql/apollo/api/Error;Lcom/apollographql/apollo/api/Error;)V
 	public static final fun assertErrorsEquals (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
+}
+
+public final class com/apollographql/cache/normalized/testing/Platform : java/lang/Enum {
+	public static final field Js Lcom/apollographql/cache/normalized/testing/Platform;
+	public static final field Jvm Lcom/apollographql/cache/normalized/testing/Platform;
+	public static final field Native Lcom/apollographql/cache/normalized/testing/Platform;
+	public static final field WasmJs Lcom/apollographql/cache/normalized/testing/Platform;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/cache/normalized/testing/Platform;
+	public static fun values ()[Lcom/apollographql/cache/normalized/testing/Platform;
+}
+
+public final class com/apollographql/cache/normalized/testing/Platform_jvmCommonKt {
+	public static final fun platform ()Lcom/apollographql/cache/normalized/testing/Platform;
+}
+
+public final class com/apollographql/cache/normalized/testing/ReadFile_concurrentKt {
+	public static final fun getHostFileSystem ()Lokio/FileSystem;
+}
+
+public final class com/apollographql/cache/normalized/testing/ReadFile_jvmKt {
+	public static final fun getTestsPath ()Ljava/lang/String;
+	public static final fun shouldUpdateTestFixtures ()Z
+}
+
+public final class com/apollographql/cache/normalized/testing/RunTestKt {
+	public static final fun runTest (Lkotlin/jvm/functions/Function2;)V
+	public static final fun runTest (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun runTest$default (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 

--- a/test-utils/api/test-utils.klib.api
+++ b/test-utils/api/test-utils.klib.api
@@ -1,13 +1,51 @@
 // Klib ABI Dump
 // Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
 // - Show declarations: true
 
 // Library unique name: <com.apollographql.cache:test-utils>
+final enum class com.apollographql.cache.normalized.testing/Platform : kotlin/Enum<com.apollographql.cache.normalized.testing/Platform> { // com.apollographql.cache.normalized.testing/Platform|null[0]
+    enum entry Js // com.apollographql.cache.normalized.testing/Platform.Js|null[0]
+    enum entry Jvm // com.apollographql.cache.normalized.testing/Platform.Jvm|null[0]
+    enum entry Native // com.apollographql.cache.normalized.testing/Platform.Native|null[0]
+    enum entry WasmJs // com.apollographql.cache.normalized.testing/Platform.WasmJs|null[0]
+
+    final val entries // com.apollographql.cache.normalized.testing/Platform.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.apollographql.cache.normalized.testing/Platform> // com.apollographql.cache.normalized.testing/Platform.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.apollographql.cache.normalized.testing/Platform // com.apollographql.cache.normalized.testing/Platform.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.apollographql.cache.normalized.testing/Platform> // com.apollographql.cache.normalized.testing/Platform.values|values#static(){}[0]
+}
+
+final val com.apollographql.cache.normalized.testing/HostFileSystem // com.apollographql.cache.normalized.testing/HostFileSystem|{}HostFileSystem[0]
+    final fun <get-HostFileSystem>(): okio/FileSystem // com.apollographql.cache.normalized.testing/HostFileSystem.<get-HostFileSystem>|<get-HostFileSystem>(){}[0]
+final val com.apollographql.cache.normalized.testing/testsPath // com.apollographql.cache.normalized.testing/testsPath|{}testsPath[0]
+    final fun <get-testsPath>(): kotlin/String // com.apollographql.cache.normalized.testing/testsPath.<get-testsPath>|<get-testsPath>(){}[0]
+
 final fun (com.apollographql.cache.normalized.api/CacheKey).com.apollographql.cache.normalized.testing/append(kotlin/Array<out kotlin/String>...): com.apollographql.cache.normalized.api/CacheKey // com.apollographql.cache.normalized.testing/append|append@com.apollographql.cache.normalized.api.CacheKey(kotlin.Array<out|kotlin.String>...){}[0]
 final fun (com.apollographql.cache.normalized.api/CacheKey).com.apollographql.cache.normalized.testing/fieldKey(kotlin/String): kotlin/String // com.apollographql.cache.normalized.testing/fieldKey|fieldKey@com.apollographql.cache.normalized.api.CacheKey(kotlin.String){}[0]
 final fun (com.apollographql.cache.normalized.api/CacheKey).com.apollographql.cache.normalized.testing/keyToString(): kotlin/String // com.apollographql.cache.normalized.testing/keyToString|keyToString@com.apollographql.cache.normalized.api.CacheKey(){}[0]
 final fun com.apollographql.cache.normalized.testing/assertErrorsEquals(com.apollographql.apollo.api/Error?, com.apollographql.apollo.api/Error?) // com.apollographql.cache.normalized.testing/assertErrorsEquals|assertErrorsEquals(com.apollographql.apollo.api.Error?;com.apollographql.apollo.api.Error?){}[0]
 final fun com.apollographql.cache.normalized.testing/assertErrorsEquals(kotlin.collections/Iterable<com.apollographql.apollo.api/Error>?, kotlin.collections/Iterable<com.apollographql.apollo.api/Error>?) // com.apollographql.cache.normalized.testing/assertErrorsEquals|assertErrorsEquals(kotlin.collections.Iterable<com.apollographql.apollo.api.Error>?;kotlin.collections.Iterable<com.apollographql.apollo.api.Error>?){}[0]
+final fun com.apollographql.cache.normalized.testing/currentThreadId(): kotlin/String // com.apollographql.cache.normalized.testing/currentThreadId|currentThreadId(){}[0]
+final fun com.apollographql.cache.normalized.testing/pathToJsonReader(kotlin/String): com.apollographql.apollo.api.json/JsonReader // com.apollographql.cache.normalized.testing/pathToJsonReader|pathToJsonReader(kotlin.String){}[0]
+final fun com.apollographql.cache.normalized.testing/pathToUtf8(kotlin/String): kotlin/String // com.apollographql.cache.normalized.testing/pathToUtf8|pathToUtf8(kotlin.String){}[0]
+final fun com.apollographql.cache.normalized.testing/platform(): com.apollographql.cache.normalized.testing/Platform // com.apollographql.cache.normalized.testing/platform|platform(){}[0]
+final fun com.apollographql.cache.normalized.testing/shouldUpdateTestFixtures(): kotlin/Boolean // com.apollographql.cache.normalized.testing/shouldUpdateTestFixtures|shouldUpdateTestFixtures(){}[0]
+final suspend fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/Channel<#A>).com.apollographql.cache.normalized.testing/assertNoElement(kotlin/Long = ...) // com.apollographql.cache.normalized.testing/assertNoElement|assertNoElement@kotlinx.coroutines.channels.Channel<0:0>(kotlin.Long){0§<kotlin.Any?>}[0]
+final suspend fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/Channel<#A>).com.apollographql.cache.normalized.testing/awaitElement(kotlin/Long = ...): #A // com.apollographql.cache.normalized.testing/awaitElement|awaitElement@kotlinx.coroutines.channels.Channel<0:0>(kotlin.Long){0§<kotlin.Any?>}[0]
+
+// Targets: [apple]
+final fun com.apollographql.cache.normalized.testing/runTest(kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit> = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit> = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>) // com.apollographql.cache.normalized.testing/runTest|runTest(kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]
+
+// Targets: [apple]
+final fun com.apollographql.cache.normalized.testing/runTest(kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>) // com.apollographql.cache.normalized.testing/runTest|runTest(kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]
+
+// Targets: [js, wasmJs]
+final fun com.apollographql.cache.normalized.testing/runTest(kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit> = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit> = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // com.apollographql.cache.normalized.testing/runTest|runTest(kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]
+
+// Targets: [js, wasmJs]
+final fun com.apollographql.cache.normalized.testing/runTest(kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // com.apollographql.cache.normalized.testing/runTest|runTest(kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -14,8 +14,14 @@ kotlin {
   sourceSets {
     getByName("commonMain") {
       dependencies {
+        api(libs.kotlinx.coroutines.test)
         api(project(":normalized-cache-incubating"))
         implementation(libs.kotlin.test)
+      }
+    }
+    getByName("jsMain") {
+      dependencies {
+        api(libs.okio.nodefilesystem)
       }
     }
   }

--- a/test-utils/src/appleMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.apple.kt
+++ b/test-utils/src/appleMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.apple.kt
@@ -1,0 +1,9 @@
+package com.apollographql.cache.normalized.testing
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.pthread_self
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun currentThreadId(): String {
+  return pthread_self()?.rawValue.toString()
+}

--- a/test-utils/src/appleMain/kotlin/com/apollographql/cache/normalized/testing/platform.apple.kt
+++ b/test-utils/src/appleMain/kotlin/com/apollographql/cache/normalized/testing/platform.apple.kt
@@ -1,0 +1,9 @@
+@file:Suppress("DEPRECATION")
+
+package com.apollographql.cache.normalized.testing
+
+/**
+ * The current platform. This is used from tests because Double.toString() doesn't behave the same on JS and other platforms.
+ * Prefer more specific functions like `assertMainThreadOnNative` when possible instead of checking the platform.
+ */
+actual fun platform() = Platform.Native

--- a/test-utils/src/appleMain/kotlin/com/apollographql/cache/normalized/testing/readFile.apple.kt
+++ b/test-utils/src/appleMain/kotlin/com/apollographql/cache/normalized/testing/readFile.apple.kt
@@ -1,0 +1,5 @@
+package com.apollographql.cache.normalized.testing
+
+actual fun shouldUpdateTestFixtures(): Boolean = false
+
+actual val testsPath: String = "../"

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/FilesystemCommon.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/FilesystemCommon.kt
@@ -1,0 +1,32 @@
+@file:JvmName("-FileSystemCommon")
+
+package com.apollographql.cache.normalized.testing
+
+import com.apollographql.apollo.api.json.JsonReader
+import com.apollographql.apollo.api.json.jsonReader
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.buffer
+import kotlin.jvm.JvmName
+
+
+private fun String.toTestsPath(): Path {
+  @Suppress("DEPRECATION")
+  return testsPath.toPath().resolve(this.toPath())
+}
+
+/**
+ * @param path: the path to the file, from the "tests" directory
+ */
+fun pathToUtf8(path: String): String {
+  @Suppress("DEPRECATION")
+  return HostFileSystem.openReadOnly(path.toTestsPath()).source().buffer().readUtf8()
+}
+
+/**
+ * @param path: the path to the file, from the "tests" directory
+ */
+fun pathToJsonReader(path: String): JsonReader {
+  @Suppress("DEPRECATION")
+  return HostFileSystem.openReadOnly(path.toTestsPath()).source().buffer().jsonReader()
+}

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/channels.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/channels.kt
@@ -1,0 +1,20 @@
+package com.apollographql.cache.normalized.testing
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
+
+suspend fun <T> Channel<T>.awaitElement(timeoutMillis: Long = 30000) = withTimeout(timeoutMillis) {
+  receive()
+}
+
+suspend fun <T> Channel<T>.assertNoElement(timeoutMillis: Long = 300): Unit {
+  try {
+    withTimeout(timeoutMillis) {
+      receive()
+    }
+    error("An item was unexpectedly received")
+  } catch (_: TimeoutCancellationException) {
+    // nothing
+  }
+}

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.kt
@@ -1,0 +1,3 @@
+package com.apollographql.cache.normalized.testing
+
+expect fun currentThreadId(): String

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/platform.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/platform.kt
@@ -1,0 +1,12 @@
+@file:Suppress("DEPRECATION")
+
+package com.apollographql.cache.normalized.testing
+
+enum class Platform {
+  Jvm,
+  Native,
+  Js,
+  WasmJs
+}
+
+expect fun platform(): Platform

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/readFile.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/readFile.kt
@@ -1,0 +1,17 @@
+package com.apollographql.cache.normalized.testing
+
+import okio.FileSystem
+
+/**
+ * The host filesystem
+ */
+expect val HostFileSystem: FileSystem
+
+expect fun shouldUpdateTestFixtures(): Boolean
+
+/**
+ * The path to the "tests" directory. This assumes all tests are run from a predictable place relative to "tests"
+ * We need this for JS tests where the CWD is not properly set at the beginning of tests
+ */
+expect val testsPath: String
+

--- a/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/runTest.kt
+++ b/test-utils/src/commonMain/kotlin/com/apollographql/cache/normalized/testing/runTest.kt
@@ -1,0 +1,24 @@
+package com.apollographql.cache.normalized.testing
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.withContext
+
+fun runTest(
+    block: suspend CoroutineScope.() -> Unit,
+) = runTest({}, {}, block)
+
+fun runTest(
+    before: suspend CoroutineScope.() -> Unit = {},
+    after: suspend CoroutineScope.() -> Unit = {},
+    block: suspend CoroutineScope.() -> Unit,
+): TestResult {
+  return kotlinx.coroutines.test.runTest {
+    withContext(Dispatchers.Default.limitedParallelism(1)) {
+      before()
+      block()
+      after()
+    }
+  }
+}

--- a/test-utils/src/concurrentMain/kotlin/com/apollographql/cache/normalized/testing/readFile.concurrent.kt
+++ b/test-utils/src/concurrentMain/kotlin/com/apollographql/cache/normalized/testing/readFile.concurrent.kt
@@ -1,0 +1,10 @@
+package com.apollographql.cache.normalized.testing
+
+import okio.FileSystem
+import okio.SYSTEM
+
+/**
+ * The host filesystem
+ */
+actual val HostFileSystem: FileSystem
+  get() = FileSystem.SYSTEM

--- a/test-utils/src/jsCommonMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.jsCommon.kt
+++ b/test-utils/src/jsCommonMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.jsCommon.kt
@@ -1,0 +1,5 @@
+package com.apollographql.cache.normalized.testing
+
+actual fun currentThreadId(): String {
+  return "js"
+}

--- a/test-utils/src/jsMain/kotlin/com/apollographql/cache/normalized/testing/platform.js.kt
+++ b/test-utils/src/jsMain/kotlin/com/apollographql/cache/normalized/testing/platform.js.kt
@@ -1,0 +1,10 @@
+@file:Suppress("DEPRECATION")
+
+package com.apollographql.cache.normalized.testing
+
+/**
+ * The current platform. This is used from tests because Double.toString() doesn't behave the same on JS and other platforms.
+ * Prefer more specific functions like `assertMainThreadOnNative` when possible instead of checking the platform.
+ */
+actual fun platform() = Platform.Js
+

--- a/test-utils/src/jsMain/kotlin/com/apollographql/cache/normalized/testing/readFile.js.kt
+++ b/test-utils/src/jsMain/kotlin/com/apollographql/cache/normalized/testing/readFile.js.kt
@@ -1,0 +1,11 @@
+package com.apollographql.cache.normalized.testing
+
+import okio.FileSystem
+import okio.NodeJsFileSystem
+
+actual val HostFileSystem: FileSystem = NodeJsFileSystem
+
+actual fun shouldUpdateTestFixtures(): Boolean = false
+
+// Workaround for https://youtrack.jetbrains.com/issue/KT-49125
+actual val testsPath: String = "../../../../../tests/"

--- a/test-utils/src/jvmCommonMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.jvmCommon.kt
+++ b/test-utils/src/jvmCommonMain/kotlin/com/apollographql/cache/normalized/testing/currentThreadId.jvmCommon.kt
@@ -1,0 +1,6 @@
+package com.apollographql.cache.normalized.testing
+
+actual fun currentThreadId(): String {
+  @Suppress("DEPRECATION")
+  return Thread.currentThread().id.toString()
+}

--- a/test-utils/src/jvmCommonMain/kotlin/com/apollographql/cache/normalized/testing/platform.jvmCommon.kt
+++ b/test-utils/src/jvmCommonMain/kotlin/com/apollographql/cache/normalized/testing/platform.jvmCommon.kt
@@ -1,0 +1,9 @@
+@file:Suppress("DEPRECATION")
+
+package com.apollographql.cache.normalized.testing
+
+/**
+ * The current platform. This is used from tests because Double.toString() doesn't behave the same on JS and other platforms.
+ * Prefer more specific functions like `assertMainThreadOnNative` when possible instead of checking the platform.
+ */
+actual fun platform() = Platform.Jvm

--- a/test-utils/src/jvmMain/kotlin/com/apollographql/cache/normalized/testing/readFile.jvm.kt
+++ b/test-utils/src/jvmMain/kotlin/com/apollographql/cache/normalized/testing/readFile.jvm.kt
@@ -1,0 +1,14 @@
+package com.apollographql.cache.normalized.testing
+
+actual fun shouldUpdateTestFixtures(): Boolean {
+  if (System.getenv("updateTestFixtures") != null) {
+    return true
+  }
+
+  return when (System.getProperty("updateTestFixtures")?.trim()) {
+    "on", "true", "1" -> true
+    else -> false
+  }
+}
+
+actual val testsPath: String = "../"

--- a/test-utils/src/wasmJsMain/kotlin/com/apollographql/cache/normalized/testing/platform.wasmJs.kt
+++ b/test-utils/src/wasmJsMain/kotlin/com/apollographql/cache/normalized/testing/platform.wasmJs.kt
@@ -1,0 +1,9 @@
+@file:Suppress("DEPRECATION")
+
+package com.apollographql.cache.normalized.testing
+
+/**
+ * The current platform. This is used from tests because Double.toString() doesn't behave the same on JS and other platforms.
+ * Prefer more specific functions like `assertMainThreadOnNative` when possible instead of checking the platform.
+ */
+actual fun platform() = Platform.WasmJs

--- a/test-utils/src/wasmJsMain/kotlin/com/apollographql/cache/normalized/testing/readFile.wasmJs.kt
+++ b/test-utils/src/wasmJsMain/kotlin/com/apollographql/cache/normalized/testing/readFile.wasmJs.kt
@@ -1,0 +1,20 @@
+package com.apollographql.cache.normalized.testing
+
+import okio.FileSystem
+
+/**
+ * The host filesystem
+ */
+actual val HostFileSystem: FileSystem
+  get() = TODO("Not yet implemented")
+
+actual fun shouldUpdateTestFixtures(): Boolean {
+  TODO("Not yet implemented")
+}
+
+/**
+ * The path to the "tests" directory. This assumes all tests are run from a predictable place relative to "tests"
+ * We need this for JS tests where the CWD is not properly set at the beginning of tests
+ */
+actual val testsPath: String
+  get() = TODO("Not yet implemented")

--- a/tests/cache-control/build.gradle.kts
+++ b/tests/cache-control/build.gradle.kts
@@ -21,11 +21,10 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
         implementation(libs.turbine)
-        implementation("com.apollographql.cache:test-utils")
       }
     }
 

--- a/tests/cache-control/src/commonTest/kotlin/ClientAndServerSideCacheControlTest.kt
+++ b/tests/cache-control/src/commonTest/kotlin/ClientAndServerSideCacheControlTest.kt
@@ -5,7 +5,6 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Query
 import com.apollographql.apollo.exception.CacheMissException
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheControlCacheResolver
 import com.apollographql.cache.normalized.api.GlobalMaxAgeProvider
@@ -22,6 +21,7 @@ import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.storeExpirationDate
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString

--- a/tests/cache-control/src/commonTest/kotlin/ClientSideCacheControlTest.kt
+++ b/tests/cache-control/src/commonTest/kotlin/ClientSideCacheControlTest.kt
@@ -3,7 +3,6 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.mpp.currentTimeMillis
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.cache.normalized.api.CacheControlCacheResolver
@@ -20,6 +19,7 @@ import com.apollographql.cache.normalized.maxStale
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import programmatic.GetCompanyQuery
 import programmatic.GetUserAdminQuery
 import programmatic.GetUserEmailQuery

--- a/tests/cache-control/src/commonTest/kotlin/DoNotStoreTest.kt
+++ b/tests/cache-control/src/commonTest/kotlin/DoNotStoreTest.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.CacheKey
@@ -26,6 +25,7 @@ import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.testing.append
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
 import com.apollographql.cache.normalized.testing.keyToString
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import donotstore.GetUserQuery

--- a/tests/cache-control/src/commonTest/kotlin/ServerSideCacheControlTest.kt
+++ b/tests/cache-control/src/commonTest/kotlin/ServerSideCacheControlTest.kt
@@ -3,7 +3,6 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.exception.CacheMissException
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheControlCacheResolver
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
@@ -14,6 +13,7 @@ import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.storeExpirationDate
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer
 import programmatic.GetUserQuery

--- a/tests/cache-variables-arguments/build.gradle.kts
+++ b/tests/cache-variables-arguments/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
       }
     }
   }

--- a/tests/cache-variables-arguments/src/commonTest/kotlin/test/IncludeTest.kt
+++ b/tests/cache-variables-arguments/src/commonTest/kotlin/test/IncludeTest.kt
@@ -2,12 +2,12 @@ package test
 
 import cache.include.GetUserQuery
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.apolloStore
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -22,9 +22,8 @@ kotlin {
     findByName("commonTest")?.apply {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
-        implementation(libs.apollo.mockserver)
         implementation("com.apollographql.cache:test-utils")
+        implementation(libs.apollo.mockserver)
       }
     }
   }

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -11,7 +11,6 @@ import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.network.NetworkTransport
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheHeaders
@@ -21,8 +20,11 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.optimisticUpdates
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.Platform
 import com.apollographql.cache.normalized.testing.append
 import com.apollographql.cache.normalized.testing.keyToString
+import com.apollographql.cache.normalized.testing.platform
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.assertNoRequest
 import com.apollographql.mockserver.awaitRequest
@@ -532,7 +534,7 @@ class DeferNormalizedCacheTest {
   @Test
   fun intermediatePayloadsAreCached() = runTest(before = { setUp() }, after = { tearDown() }) {
     @Suppress("DEPRECATION")
-    if (com.apollographql.apollo.testing.platform() == com.apollographql.apollo.testing.Platform.Js) {
+    if (platform() == Platform.Js) {
       // TODO For now chunked is not supported on JS - remove this check when it is
       return@runTest
     }

--- a/tests/garbage-collection/build.gradle.kts
+++ b/tests/garbage-collection/build.gradle.kts
@@ -21,10 +21,9 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
-        implementation("com.apollographql.cache:test-utils")
       }
     }
   }

--- a/tests/garbage-collection/src/commonTest/kotlin/DanglingReferencesTest.kt
+++ b/tests/garbage-collection/src/commonTest/kotlin/DanglingReferencesTest.kt
@@ -1,7 +1,6 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.allRecords
@@ -13,6 +12,7 @@ import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
 import com.apollographql.cache.normalized.testing.append
 import com.apollographql.cache.normalized.testing.fieldKey
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import kotlinx.coroutines.test.TestResult

--- a/tests/garbage-collection/src/commonTest/kotlin/GarbageCollectTest.kt
+++ b/tests/garbage-collection/src/commonTest/kotlin/GarbageCollectTest.kt
@@ -1,7 +1,6 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.allRecords
@@ -15,6 +14,7 @@ import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
 import com.apollographql.cache.normalized.testing.append
 import com.apollographql.cache.normalized.testing.fieldKey
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import okio.use

--- a/tests/garbage-collection/src/commonTest/kotlin/ReachableCacheKeysTest.kt
+++ b/tests/garbage-collection/src/commonTest/kotlin/ReachableCacheKeysTest.kt
@@ -1,7 +1,6 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.allRecords
@@ -13,6 +12,7 @@ import com.apollographql.cache.normalized.removeUnreachableRecords
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
 import com.apollographql.cache.normalized.storeReceivedDate
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import okio.use

--- a/tests/garbage-collection/src/commonTest/kotlin/StaleFieldsTest.kt
+++ b/tests/garbage-collection/src/commonTest/kotlin/StaleFieldsTest.kt
@@ -2,7 +2,6 @@ package test
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.mpp.currentTimeMillis
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.allRecords
@@ -19,6 +18,7 @@ import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
 import com.apollographql.cache.normalized.testing.append
 import com.apollographql.cache.normalized.testing.fieldKey
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import okio.use

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     findByName("commonTest")?.apply {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
       }
     }

--- a/tests/include-skip-operation-based/src/commonTest/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/commonTest/kotlin/IncludeTest.kt
@@ -4,9 +4,9 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.json.MapJsonReader
 import com.apollographql.apollo.api.toApolloResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.internal.normalized
+import com.apollographql.cache.normalized.testing.runTest
 import com.example.GetCatIncludeVariableWithDefaultQuery
 import com.example.SkipFragmentWithDefaultToFalseQuery
 import com.example.type.buildCat

--- a/tests/migration/build.gradle.kts
+++ b/tests/migration/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
       }

--- a/tests/migration/src/commonTest/kotlin/MigrationTest.kt
+++ b/tests/migration/src/commonTest/kotlin/MigrationTest.kt
@@ -3,7 +3,6 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.mpp.currentTimeMillis
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheHeaders
@@ -15,6 +14,7 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import okio.use

--- a/tests/models-operation-based-with-interfaces/build.gradle.kts
+++ b/tests/models-operation-based-with-interfaces/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
       }

--- a/tests/models-operation-based-with-interfaces/src/commonTest/kotlin/Utils.kt
+++ b/tests/models-operation-based-with-interfaces/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,4 @@
-import com.apollographql.apollo.testing.pathToUtf8
+import com.apollographql.cache.normalized.testing.pathToUtf8
 
 @Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("models-fixtures/json/$name")

--- a/tests/models-operation-based-with-interfaces/src/commonTest/kotlin/test/BasicTest.kt
+++ b/tests/models-operation-based-with-interfaces/src/commonTest/kotlin/test/BasicTest.kt
@@ -7,13 +7,13 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import testFixtureToUtf8

--- a/tests/models-operation-based-with-interfaces/src/commonTest/kotlin/test/StoreTest.kt
+++ b/tests/models-operation-based-with-interfaces/src/commonTest/kotlin/test/StoreTest.kt
@@ -7,12 +7,12 @@ import codegen.models.fragment.HeroWithFriendsFragmentImpl
 import codegen.models.fragment.HumanWithIdFragment
 import codegen.models.fragment.HumanWithIdFragmentImpl
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import testFixtureToUtf8

--- a/tests/models-operation-based/build.gradle.kts
+++ b/tests/models-operation-based/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
       }

--- a/tests/models-operation-based/src/commonTest/kotlin/Utils.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,4 @@
-import com.apollographql.apollo.testing.pathToUtf8
+import com.apollographql.cache.normalized.testing.pathToUtf8
 
 @Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("models-fixtures/json/$name")

--- a/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -7,13 +7,13 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import testFixtureToUtf8

--- a/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -7,12 +7,12 @@ import codegen.models.fragment.HeroWithFriendsFragmentImpl
 import codegen.models.fragment.HumanWithIdFragment
 import codegen.models.fragment.HumanWithIdFragmentImpl
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import testFixtureToUtf8

--- a/tests/models-response-based/build.gradle.kts
+++ b/tests/models-response-based/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
       }

--- a/tests/models-response-based/src/commonTest/kotlin/Utils.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,4 @@
-import com.apollographql.apollo.testing.pathToUtf8
+import com.apollographql.cache.normalized.testing.pathToUtf8
 
 @Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("models-fixtures/json/$name")

--- a/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -12,13 +12,13 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import testFixtureToUtf8

--- a/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -8,12 +8,12 @@ import codegen.models.fragment.HeroWithFriendsFragment.Friend.Companion.humanWit
 import codegen.models.fragment.HeroWithFriendsFragmentImpl
 import codegen.models.fragment.HumanWithIdFragmentImpl
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import testFixtureToUtf8

--- a/tests/normalization-tests/build.gradle.kts
+++ b/tests/normalization-tests/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
       }

--- a/tests/normalization-tests/src/commonTest/kotlin/com/example/NormalizationTest.kt
+++ b/tests/normalization-tests/src/commonTest/kotlin/com/example/NormalizationTest.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.json.jsonReader
 import com.apollographql.apollo.api.toApolloResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
@@ -19,6 +18,7 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import com.example.one.Issue2818Query

--- a/tests/normalized-cache/build.gradle.kts
+++ b/tests/normalized-cache/build.gradle.kts
@@ -28,10 +28,10 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
         implementation(libs.turbine)
-        implementation("com.apollographql.cache:test-utils")
       }
     }
 

--- a/tests/normalized-cache/src/commonTest/kotlin/BasicTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/BasicTest.kt
@@ -3,13 +3,13 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import httpcache.AllPlanetsQuery

--- a/tests/normalized-cache/src/commonTest/kotlin/CacheFlagsTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/CacheFlagsTest.kt
@@ -10,7 +10,6 @@ import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.ApolloCacheHeaders
@@ -20,6 +19,7 @@ import com.apollographql.cache.normalized.doNotStore
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import normalizer.HeroNameQuery

--- a/tests/normalized-cache/src/commonTest/kotlin/CacheResolverTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/CacheResolverTest.kt
@@ -1,13 +1,13 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheResolver
 import com.apollographql.cache.normalized.api.DefaultCacheResolver
 import com.apollographql.cache.normalized.api.ResolverContext
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import normalizer.HeroNameQuery
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/tests/normalized-cache/src/commonTest/kotlin/CancelTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/CancelTest.kt
@@ -1,11 +1,11 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import kotlinx.coroutines.delay

--- a/tests/normalized-cache/src/commonTest/kotlin/ExceptionsTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/ExceptionsTest.kt
@@ -3,9 +3,9 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloNetworkException
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueError
 import com.apollographql.mockserver.enqueueString

--- a/tests/normalized-cache/src/commonTest/kotlin/FetchPolicyTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/FetchPolicyTest.kt
@@ -18,9 +18,6 @@ import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.exception.JsonEncodingException
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
-import com.apollographql.apollo.testing.assertNoElement
-import com.apollographql.apollo.testing.awaitElement
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.CacheFirstInterceptor
 import com.apollographql.cache.normalized.CacheOnlyInterceptor
@@ -31,7 +28,9 @@ import com.apollographql.cache.normalized.isFromCache
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.refetchPolicyInterceptor
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.assertNoElement
 import com.apollographql.cache.normalized.testing.fieldKey
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.awaitRequest

--- a/tests/normalized-cache/src/commonTest/kotlin/IdCacheKeyGeneratorTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/IdCacheKeyGeneratorTest.kt
@@ -3,7 +3,6 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
@@ -11,6 +10,7 @@ import com.apollographql.cache.normalized.api.IdCacheKeyResolver
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import main.GetUser2Query
 import main.GetUserByIdQuery
 import main.GetUsersByIDsQuery

--- a/tests/normalized-cache/src/commonTest/kotlin/JsonScalarTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/JsonScalarTest.kt
@@ -2,12 +2,12 @@ package test
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.AnyAdapter
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import normalizer.GetJsonScalarQuery

--- a/tests/normalized-cache/src/commonTest/kotlin/MemoryCacheTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/MemoryCacheTest.kt
@@ -1,11 +1,11 @@
 package test
 
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.DefaultRecordMerger
 import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.memory.MemoryCache
+import com.apollographql.cache.normalized.testing.runTest
 import kotlinx.coroutines.delay
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/tests/normalized-cache/src/commonTest/kotlin/NormalizationTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/NormalizationTest.kt
@@ -3,11 +3,11 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import main.RepositoryListQuery
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/tests/normalized-cache/src/commonTest/kotlin/NormalizedCacheThreadingTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/NormalizedCacheThreadingTest.kt
@@ -2,12 +2,12 @@ package test
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
-import com.apollographql.apollo.testing.currentThreadId
 import com.apollographql.apollo.testing.enqueueTestResponse
 import com.apollographql.cache.normalized.api.NormalizedCache
 import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.currentThreadId
 import kotlinx.coroutines.test.runTest
 import normalizer.CharacterNameByIdQuery
 import kotlin.test.Test

--- a/tests/normalized-cache/src/commonTest/kotlin/OptimisticCacheTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/OptimisticCacheTest.kt
@@ -2,8 +2,6 @@ package test
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.testing.awaitElement
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
@@ -13,6 +11,7 @@ import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.optimisticUpdates
 import com.apollographql.cache.normalized.refetchPolicy
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString

--- a/tests/normalized-cache/src/commonTest/kotlin/OtherCacheTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/OtherCacheTest.kt
@@ -3,7 +3,6 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.composeJsonResponse
 import com.apollographql.apollo.exception.CacheMissException
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
@@ -13,6 +12,7 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
 import com.apollographql.cache.normalized.testing.keyToString
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import normalizer.CharacterDetailsQuery

--- a/tests/normalized-cache/src/commonTest/kotlin/StoreTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/StoreTest.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
@@ -14,6 +13,7 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.isFromCache
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import normalizer.CharacterNameByIdQuery
 import normalizer.HeroAndFriendsNamesWithIDsQuery
 import normalizer.type.Episode

--- a/tests/normalized-cache/src/commonTest/kotlin/ThreadTests.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/ThreadTests.kt
@@ -3,11 +3,8 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.Platform
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
-import com.apollographql.apollo.testing.currentThreadId
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.platform
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.CacheKey
@@ -18,6 +15,9 @@ import com.apollographql.cache.normalized.api.RecordMerger
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCache
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.Platform
+import com.apollographql.cache.normalized.testing.currentThreadId
+import com.apollographql.cache.normalized.testing.platform
 import kotlinx.coroutines.test.runTest
 import normalizer.HeroNameQuery
 import kotlin.reflect.KClass

--- a/tests/normalized-cache/src/commonTest/kotlin/Utils.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/Utils.kt
@@ -1,7 +1,7 @@
 package test
 
-import com.apollographql.apollo.testing.pathToJsonReader
-import com.apollographql.apollo.testing.pathToUtf8
+import com.apollographql.cache.normalized.testing.pathToJsonReader
+import com.apollographql.cache.normalized.testing.pathToUtf8
 
 @Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("normalized-cache/testFixtures/$name")

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherErrorHandlingTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherErrorHandlingTest.kt
@@ -5,8 +5,6 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.CacheMissException
-import com.apollographql.apollo.testing.awaitElement
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
@@ -14,6 +12,7 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.refetchPolicy
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueError

--- a/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/WatcherTest.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestNetworkError
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
@@ -18,6 +17,7 @@ import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.refetchPolicy
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer

--- a/tests/normalized-cache/src/commonTest/kotlin/circular/CircularCacheReadTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/circular/CircularCacheReadTest.kt
@@ -1,10 +1,9 @@
 package test.circular
 
 import circular.GetUserQuery
-import com.apollographql.apollo.api.CustomScalarAdapters
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,7 +29,7 @@ class CircularCacheReadTest {
     )
 
     store.writeOperation(operation, data)
-    val result = store.readOperation(operation, customScalarAdapters = CustomScalarAdapters.Empty).data!!
+    val result = store.readOperation(operation).data!!
     assertEquals("42", result.user.friend.id)
   }
 }

--- a/tests/normalized-cache/src/commonTest/kotlin/declarativecache/DeclarativeCacheTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/declarativecache/DeclarativeCacheTest.kt
@@ -1,13 +1,12 @@
 package test.declarativecache
 
-import com.apollographql.apollo.api.CustomScalarAdapters
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.CacheResolver
 import com.apollographql.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.cache.normalized.api.ResolverContext
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import declarativecache.GetAuthorQuery
 import declarativecache.GetBookQuery
 import declarativecache.GetBooksQuery
@@ -36,7 +35,7 @@ class DeclarativeCacheTest {
     store.writeOperation(otherOperation, otherData)
 
     // Get the "promo" book again, the title must be updated
-    val data = store.readOperation(promoOperation, CustomScalarAdapters.Empty).data!!
+    val data = store.readOperation(promoOperation).data!!
 
     assertEquals("Other", data.promoBook?.title)
   }
@@ -56,7 +55,7 @@ class DeclarativeCacheTest {
     store.writeOperation(otherOperation, otherData)
 
     // Get the "promo" library again, the address must be updated
-    val data = store.readOperation(promoOperation, CustomScalarAdapters.Empty).data!!
+    val data = store.readOperation(promoOperation).data!!
 
     assertEquals("OtherAddress", data.promoLibrary?.address)
   }
@@ -70,7 +69,7 @@ class DeclarativeCacheTest {
     store.writeOperation(bookQuery1, bookData1)
 
     val bookQuery2 = GetBookQuery("42")
-    val bookData2 = store.readOperation(bookQuery2, CustomScalarAdapters.Empty).data!!
+    val bookData2 = store.readOperation(bookQuery2).data!!
 
     assertEquals("Promo", bookData2.book?.title)
 
@@ -86,7 +85,7 @@ class DeclarativeCacheTest {
     store.writeOperation(authorQuery1, authorData1)
 
     val authorQuery2 = GetAuthorQuery("Pierre", "Bordage")
-    val authorData2 = store.readOperation(authorQuery2, CustomScalarAdapters.Empty).data!!
+    val authorData2 = store.readOperation(authorQuery2).data!!
 
     assertEquals("Pierre", authorData2.author?.firstName)
     assertEquals("Bordage", authorData2.author?.lastName)
@@ -117,13 +116,13 @@ class DeclarativeCacheTest {
     store.writeOperation(promoOperation, GetPromoBookQuery.Data(GetPromoBookQuery.PromoBook("Title4", "4", "Book")))
 
     var operation = GetBooksQuery(listOf("4", "1"))
-    var data = store.readOperation(operation, CustomScalarAdapters.Empty).data!!
+    var data = store.readOperation(operation).data!!
 
     assertEquals("Title4", data.books.get(0).title)
     assertEquals("Title1", data.books.get(1).title)
 
     operation = GetBooksQuery(listOf("3"))
-    data = store.readOperation(operation, CustomScalarAdapters.Empty).data!!
+    data = store.readOperation(operation).data!!
 
     assertEquals("Title3", data.books.get(0).title)
   }

--- a/tests/normalized-cache/src/commonTest/kotlin/fragmentnormalizer/FragmentNormalizerTest.kt
+++ b/tests/normalized-cache/src/commonTest/kotlin/fragmentnormalizer/FragmentNormalizerTest.kt
@@ -1,8 +1,6 @@
 package test.fragmentnormalizer
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.api.CustomScalarAdapters
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.IdCacheKeyGenerator
 import com.apollographql.cache.normalized.apolloStore
@@ -10,6 +8,7 @@ import com.apollographql.cache.normalized.internal.normalized
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.testing.append
+import com.apollographql.cache.normalized.testing.runTest
 import fragmentnormalizer.fragment.ConversationFragment
 import fragmentnormalizer.fragment.ConversationFragmentImpl
 import kotlin.test.Test
@@ -66,14 +65,12 @@ class FragmentNormalizerTest {
         ConversationFragmentImpl(),
         CacheKey(fragment1.id),
         fragment1Read,
-        CustomScalarAdapters.Empty
     )
 
     apolloClient.apolloStore.writeFragment(
         ConversationFragmentImpl(),
         CacheKey(fragment2.id),
         fragment2Read,
-        CustomScalarAdapters.Empty
     )
 
     fragment1 = apolloClient.apolloStore.readFragment(

--- a/tests/normalized-cache/src/concurrentTest/kotlin/MemoryCacheOnlyTest.kt
+++ b/tests/normalized-cache/src/concurrentTest/kotlin/MemoryCacheOnlyTest.kt
@@ -2,7 +2,6 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
@@ -14,6 +13,7 @@ import com.apollographql.cache.normalized.memoryCacheOnly
 import com.apollographql.cache.normalized.sql.SqlNormalizedCache
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import main.GetUserQuery
 import kotlin.reflect.KClass
 import kotlin.test.Test

--- a/tests/normalized-cache/src/jvmTest/kotlin/ApqCacheTest.kt
+++ b/tests/normalized-cache/src/jvmTest/kotlin/ApqCacheTest.kt
@@ -3,9 +3,9 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.composeJsonResponse
 import com.apollographql.apollo.api.http.HttpMethod
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import normalizer.HeroNameQuery

--- a/tests/normalized-cache/src/jvmTest/kotlin/CacheConcurrencyTest.kt
+++ b/tests/normalized-cache/src/jvmTest/kotlin/CacheConcurrencyTest.kt
@@ -3,10 +3,10 @@ package test
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch

--- a/tests/normalized-cache/src/jvmTest/kotlin/CacheMissLoggingInterceptorTest.kt
+++ b/tests/normalized-cache/src/jvmTest/kotlin/CacheMissLoggingInterceptorTest.kt
@@ -1,7 +1,6 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.fetchPolicy
@@ -9,6 +8,7 @@ import com.apollographql.cache.normalized.logCacheMisses
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.testing.keyToString
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import normalizer.HeroAppearsInQuery

--- a/tests/normalized-cache/src/jvmTest/kotlin/WriteToCacheAsynchronouslyTest.kt
+++ b/tests/normalized-cache/src/jvmTest/kotlin/WriteToCacheAsynchronouslyTest.kt
@@ -1,12 +1,12 @@
 package test
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheHeaders
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.store
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.writeToCacheAsynchronously
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString

--- a/tests/number-scalar/build.gradle.kts
+++ b/tests/number-scalar/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.kotlin.test)
       }
     }

--- a/tests/number-scalar/src/commonTest/kotlin/test/NumberTest.kt
+++ b/tests/number-scalar/src/commonTest/kotlin/test/NumberTest.kt
@@ -8,11 +8,11 @@ import com.apollographql.apollo.api.json.JsonReader
 import com.apollographql.apollo.api.json.JsonWriter
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import com.example.GetNumberQuery
 import okio.use
 import kotlin.test.Test

--- a/tests/optimistic-data/build.gradle.kts
+++ b/tests/optimistic-data/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.turbine)
       }

--- a/tests/optimistic-data/src/jvmTest/kotlin/test/OptimisticDataTest.kt
+++ b/tests/optimistic-data/src/jvmTest/kotlin/test/OptimisticDataTest.kt
@@ -2,10 +2,10 @@ package test
 
 import app.cash.turbine.test
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.optimisticUpdates
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.cache.normalized.watch
 import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer

--- a/tests/pagination/build.gradle.kts
+++ b/tests/pagination/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
       }

--- a/tests/pagination/src/commonTest/kotlin/ConnectionPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/ConnectionPaginationTest.kt
@@ -2,7 +2,6 @@ package pagination
 
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.ConnectionMetadataGenerator
 import com.apollographql.cache.normalized.api.ConnectionRecordMerger
@@ -11,6 +10,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import pagination.connection.UsersQuery
 import pagination.connection.pagination.Pagination
 import pagination.connection.type.buildPageInfo

--- a/tests/pagination/src/commonTest/kotlin/ConnectionProgrammaticPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/ConnectionProgrammaticPaginationTest.kt
@@ -1,7 +1,6 @@
 package pagination
 
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.ConnectionEmbeddedFieldsProvider
 import com.apollographql.cache.normalized.api.ConnectionFieldKeyGenerator
@@ -12,6 +11,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import pagination.connectionProgrammatic.UsersQuery
 import pagination.connectionProgrammatic.type.Query
 import pagination.connectionProgrammatic.type.UserConnection

--- a/tests/pagination/src/commonTest/kotlin/ConnectionWithNodesPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/ConnectionWithNodesPaginationTest.kt
@@ -1,7 +1,6 @@
 package pagination
 
 import com.apollographql.apollo.api.Optional
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.ConnectionMetadataGenerator
 import com.apollographql.cache.normalized.api.ConnectionRecordMerger
@@ -10,6 +9,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import pagination.connectionWithNodes.UsersQuery
 import pagination.connectionWithNodes.pagination.Pagination
 import pagination.connectionWithNodes.type.buildPageInfo

--- a/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.testing.QueueTestNetworkTransport
 import com.apollographql.apollo.testing.enqueueTestResponse
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.ConnectionMetadataGenerator
@@ -16,6 +15,7 @@ import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import kotlinx.coroutines.flow.toList
 import pagination.cursorBased.UsersQuery
 import pagination.cursorBased.type.buildPageInfo

--- a/tests/pagination/src/commonTest/kotlin/EmbedTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/EmbedTest.kt
@@ -1,7 +1,6 @@
 package pagination
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.cache.normalized.api.CacheKeyGeneratorContext
@@ -9,6 +8,7 @@ import com.apollographql.cache.normalized.apolloStore
 import com.apollographql.cache.normalized.internal.normalized
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.testing.runTest
 import embed.GetHeroQuery
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
@@ -2,7 +2,6 @@ package pagination
 
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.json.ApolloJsonElement
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.cache.normalized.api.FieldRecordMerger
@@ -12,6 +11,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import pagination.offsetBasedWithArray.UsersQuery
 import pagination.offsetBasedWithArray.type.buildUser
 import kotlin.math.max

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPageAndInputPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPageAndInputPaginationTest.kt
@@ -5,7 +5,6 @@ import com.apollographql.apollo.api.CompiledField
 import com.apollographql.apollo.api.Executable
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.json.ApolloJsonElement
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.DefaultFieldKeyGenerator
 import com.apollographql.cache.normalized.api.FieldKeyContext
@@ -18,6 +17,7 @@ import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import pagination.offsetBasedWithPageAndInput.UsersQuery
 import pagination.offsetBasedWithPageAndInput.type.buildUser
 import pagination.offsetBasedWithPageAndInput.type.buildUserPage

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
@@ -2,7 +2,6 @@ package pagination
 
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.json.ApolloJsonElement
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.api.CacheKey
 import com.apollographql.cache.normalized.api.FieldPolicyCacheResolver
@@ -14,6 +13,7 @@ import com.apollographql.cache.normalized.api.Record
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.testing.runTest
 import pagination.offsetBasedWithPage.UsersQuery
 import pagination.offsetBasedWithPage.type.buildUser
 import pagination.offsetBasedWithPage.type.buildUserPage

--- a/tests/partial-results/build.gradle.kts
+++ b/tests/partial-results/build.gradle.kts
@@ -21,10 +21,9 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
-        implementation("com.apollographql.cache:test-utils")
       }
     }
 

--- a/tests/partial-results/src/commonTest/kotlin/test/CachePartialResultTest.kt
+++ b/tests/partial-results/src/commonTest/kotlin/test/CachePartialResultTest.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheControlCacheResolver
@@ -29,6 +28,7 @@ import com.apollographql.cache.normalized.storeReceivedDate
 import com.apollographql.cache.normalized.testing.append
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
 import com.apollographql.cache.normalized.testing.keyToString
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import kotlinx.coroutines.flow.Flow

--- a/tests/schema-changes/build.gradle.kts
+++ b/tests/schema-changes/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
     getByName("commonTest") {
       dependencies {
         implementation(libs.kotlin.test)
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.turbine)
       }

--- a/tests/schema-changes/src/commonTest/kotlin/test/SchemaChanges.kt
+++ b/tests/schema-changes/src/commonTest/kotlin/test/SchemaChanges.kt
@@ -2,9 +2,9 @@ package test
 
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.json.jsonReader
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.cache.normalized.internal.normalized
+import com.apollographql.cache.normalized.testing.runTest
 import okio.Buffer
 import schema.changes.GetFieldQuery
 import kotlin.test.Test

--- a/tests/store-errors/build.gradle.kts
+++ b/tests/store-errors/build.gradle.kts
@@ -21,10 +21,9 @@ kotlin {
 
     getByName("commonTest") {
       dependencies {
-        implementation(libs.apollo.testing.support)
+        implementation("com.apollographql.cache:test-utils")
         implementation(libs.apollo.mockserver)
         implementation(libs.kotlin.test)
-        implementation("com.apollographql.cache:test-utils")
       }
     }
 

--- a/tests/store-errors/src/commonTest/kotlin/test/StoreErrorsTest.kt
+++ b/tests/store-errors/src/commonTest/kotlin/test/StoreErrorsTest.kt
@@ -8,7 +8,6 @@ import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
-import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.api.CacheKey
@@ -22,6 +21,7 @@ import com.apollographql.cache.normalized.memory.MemoryCacheFactory
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.cache.normalized.store
 import com.apollographql.cache.normalized.testing.assertErrorsEquals
+import com.apollographql.cache.normalized.testing.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import kotlinx.coroutines.flow.Flow


### PR DESCRIPTION
Copied a few utilities from there, since it's no longer published.